### PR TITLE
Makefile の target を godwhale_child に、コンパイラを clang++ に

### DIFF
--- a/source/Makefile
+++ b/source/Makefile
@@ -6,8 +6,8 @@ YANEURAOU_EDITION = YANEURAOU_2018_OTAFUKU_ENGINE
 
 
 # clangでコンパイルしたほうがgccより数%速いっぽい。
-COMPILER = g++
-#COMPILER = clang++
+#COMPILER = g++
+COMPILER = clang++
 
 # 標準的なコンパイルオプション
 CFLAGS   = -std=c++14 -fno-exceptions -fno-rtti -Wextra -Ofast -MMD -MP -fpermissive
@@ -38,10 +38,10 @@ endif
 ifeq ($(OS),Windows_NT)
 	CFLAGS += $(WCFLAGS)
 	LDFLAGS += -static -Wl,--stack,100000000
-	TARGET = YaneuraOu-by-gcc.exe
+	TARGET = godwhale_child.exe
 else
 	CFLAGS += -D_LINUX -DGODWHALE_CLUSTER_SLAVE
-	TARGET = YaneuraOu-by-gcc
+	TARGET = godwhale_child
 endif
 
 # リンク時最適化。これをつけるとmsys2環境だとセグフォで落ちる。


### PR DESCRIPTION
おそらく Linux でしか使わないと思うのでコンパイラを修正してみました。
```
$ sudo apt-get update
$ sudo apt-get install clang-3.9 libc++-dev libboost-system-dev
$ sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-3.9 100
```
で、``make -j `nproc` tournament`` くらいでいけるかと。
あと、出力を run-loop.sh にあるバイナリと思じ名前にしてみました。