### PR TITLE
Add: boostによるevalshareの実装の追加(参照実装)

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8)
 
 set(CMAKE_CXX_COMPILER "clang++")
-add_definitions("-std=c++14 -fno-exceptions -fno-rtti -Wextra -Ofast -MMD -MP")
+add_definitions("-std=c++14 -fno-exceptions -frtti -Wextra -Ofast -MMD -MP")
 add_definitions("-Wno-unused-parameter -D_LINUX -DGODWHALE_CLUSTER_SLAVE -DUSE_CMAKE")
 set(CMAKE_EXE_LINKER_FLAGS "-v")
 

--- a/source/Makefile
+++ b/source/Makefile
@@ -10,7 +10,7 @@ YANEURAOU_EDITION = YANEURAOU_2018_OTAFUKU_ENGINE
 COMPILER = clang++
 
 # 標準的なコンパイルオプション
-CFLAGS   = -std=c++14 -fno-exceptions -fno-rtti -Wextra -Ofast -MMD -MP -fpermissive
+CFLAGS   = -std=c++14 -fno-exceptions -frtti -Wextra -Ofast -MMD -MP -fpermissive
 WCFLAGS  =
 LDFLAGS  =
 LIBS     =

--- a/source/shogi.cpp
+++ b/source/shogi.cpp
@@ -257,6 +257,10 @@ int main(int argc, char* argv[])
 			Options["Login_Name"] << USI::Option(loginName);
 			if (argc > 4) {
 				Options["Threads"] = argv[4];
+				// 1スレの時はテストとみなして共有メモリがデフォ
+				if(1 == (size_t)Options["Threads"]){
+					Options["EvalShare"] << USI::Option(true);
+				}
 			}
 
 			IsGodwhaleMode = true;

--- a/source/usi.cpp
+++ b/source/usi.cpp
@@ -391,12 +391,18 @@ namespace USI
 		// 評価関数フォルダ。これを変更したとき、評価関数を次のisreadyタイミングで読み直す必要がある。
 		o["EvalDir"] << Option("eval", [](const USI::Option&o) { load_eval_finished = false; });
 
+#if defined(GODWHALE_CLUSTER_SLAVE)
+		// 評価関数パラメーターを共有するか
+		// デフォルトでオフにする。
+		o["EvalShare"] << Option(false);
+#else
 #if defined (USE_SHARED_MEMORY_IN_EVAL) && defined(_WIN32) && \
 	 (defined(EVAL_KPPT) || defined(EVAL_KPP_KKPT) || defined(EVAL_KPPPT) || defined(EVAL_KPPP_KKPT) || defined(EVAL_KKPP_KKPT) || \
 	defined(EVAL_KPP_KKPT_FV_VAR) || defined(EVAL_KKPPT) ||defined(EVAL_EXPERIMENTAL) || defined(EVAL_HELICES) || defined(EVAL_NABLA) )
 		// 評価関数パラメーターを共有するか
 		// 異種評価関数との自己対局のときにこの設定で引っかかる人が後を絶たないのでデフォルトでオフにする。
 		o["EvalShare"] << Option(false);
+#endif
 #endif
 
 #if defined(LOCAL_GAME_SERVER)


### PR DESCRIPTION
Issueが書けなかったので、PRにしてご報告。(マージしないでください)

結論から言うと、Linuxはいけましたが、msys2 clang はダメっぽいです、たぶん。
具体的には `-fno-rtti` を外すとリンカーエラーが出ます。
https://ci.appveyor.com/project/ohga/yaneuraou/build/1.0.40/job/n183m8qr3kjo13bh#L278
`godwhale_io.cpp`と`libboost_system-mt.a`で`error_category`の定義がダブって見えてるとか？です。

想像ですが、msys2のclangのバージョンが古いのか、`-static` しようとしてるのが悪いのか、かな、と。